### PR TITLE
Fixed a crash when CreativeCore is not installed

### DIFF
--- a/src/main/java/com/creativemd/cmdcam/CMDCam.java
+++ b/src/main/java/com/creativemd/cmdcam/CMDCam.java
@@ -17,7 +17,7 @@ import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 
-@Mod(modid = CMDCam.modid, version = CMDCam.version, name = "CMDCam")
+@Mod(modid = CMDCam.modid, version = CMDCam.version, name = "CMDCam", dependencies = "required-after:creativecore")
 public class CMDCam {
 	
 	public static final String modid = "cmdcam";


### PR DESCRIPTION
Now Forge will tell the user to install CreativeCore (instead of crashing Minecraft)